### PR TITLE
keep process and update in separate steps

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -82,30 +82,37 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "VERSION_CODE=$VERSION_CODE" >> $GITHUB_ENV
 
-      - name: Process CHANGELOG.md and Update changelog.xml
+      - name: Process Changelog Changes
         id: process-changelog
         run: |
-          # Extract Unreleased section
-          UNRELEASED=$(sed -n '/## \[Unreleased\]/,/^## /p' CHANGELOG.md | sed '1,2d' | sed '$d')
-          if [ -z "$UNRELEASED" ]; then
-            echo "No changes found in Unreleased. Exiting."
-            exit 1
+          unreleased_section=$(sed -n '/## \[Unreleased\]/,/^## /p' CHANGELOG.md | sed '1,2d' | sed '$d')
+
+          if [ -z "$unreleased_section" ]; then
+            changelog_escaped="No release notes"
+          else
+            changelog_escaped=$(echo "$unreleased_section" | sed 's/^- /\u2714 /g' | sed ':a;N;$!ba;s/\n/%0A/g')
           fi
 
-          # Format release notes for GitHub body
-          RELEASE_NOTES=""
-          echo "$UNRELEASED" | awk 'BEGIN {FS=" - "; OFS=":"} 
-            /^- / {if ($2 ~ /https/) {print "- ✔", $1, "(" $2 ")"} else {print "- ✔", $1}}' > RELEASE_NOTES.tmp
-          RELEASE_NOTES=$(cat RELEASE_NOTES.tmp | tr '\n' '%0A')
-          echo "RELEASE_NOTES=$RELEASE_NOTES" >> $GITHUB_ENV
+          echo "changelog_additions=$changelog_escaped" >> $GITHUB_OUTPUT
 
-          # Process changelog.xml mapping types
-          NEW_NOTES=$(echo "$UNRELEASED" | grep "^- " | sed 's/^- /<new>/g' | sed 's/ (https.*)/<\/new>/g')
-          INFO_NOTES=$(echo "$UNRELEASED" | grep "^* " | sed 's/^* /<info>/g' | sed 's/ (https.*)/<\/info>/g')
-          BUGFIX_NOTES=$(echo "$UNRELEASED" | grep "^~ " | sed 's/^~ /<bugfix>/g' | sed 's/ (https.*)/<\/bugfix>/g')
+          today=$(date +'%Y-%m-%d')
+          sed -i "s/## \[Unreleased\]/## [v$VERSION] - $today/" CHANGELOG.md
+          sed -i '/## \[v'$VERSION'\]/i ## [Unreleased]\n\n### Added\n\n### Changed\n\n### Fixed\n' CHANGELOG.md
 
-          # Append to changelog.xml
-          today=$(date +%Y-%m-%d)
+          REPO_URL="https://github.com/${{ github.repository }}/releases/tag"
+          printf "\n[v$VERSION]: $REPO_URL/$VERSION" >> CHANGELOG.md
+
+      - name: Update changelog.xml
+        id: update-changelog-xml
+        run: |
+          # Extract and classify changes
+          unreleased_section=$(sed -n '/## \[v'$VERSION'\]/,/^## /p' CHANGELOG.md | sed '1,2d' | sed '$d')
+
+          NEW_NOTES=$(echo "$unreleased_section" | grep -E '^- ' | sed 's/^- /<new>/;s/$/<\/new>/')
+          INFO_NOTES=$(echo "$unreleased_section" | grep -E '^- ' | sed 's/^- /<info>/;s/$/<\/info>/')
+          BUGFIX_NOTES=$(echo "$unreleased_section" | grep -E '^- ' | sed 's/^- /<bugfix>/;s/$/<\/bugfix>/')
+
+          today=$(date +'%Y-%m-%d')
           echo "    <release date=\"$today\" versionCode=\"$VERSION_CODE\" versionName=\"v$VERSION\">" > RELEASE_BLOCK.tmp
           echo "$NEW_NOTES" >> RELEASE_BLOCK.tmp
           echo "$INFO_NOTES" >> RELEASE_BLOCK.tmp
@@ -113,10 +120,6 @@ jobs:
           echo "    </release>" >> RELEASE_BLOCK.tmp
 
           sed -i "/<\/changelog>/i $(cat RELEASE_BLOCK.tmp)" app/src/main/res/raw/changelog.xml
-
-          # Replace Unreleased section with versioned release
-          sed -i "s/## \[Unreleased\]/## [v$VERSION] - $today/" CHANGELOG.md
-          sed -i '/## \[v'$VERSION'\]/i ## [Unreleased]\n\n### Added\n\n### Changed\n\n### Fixed\n' CHANGELOG.md
 
       - name: Set Up Build Environment
         uses: actions/setup-java@v3
@@ -159,7 +162,7 @@ jobs:
           tag: "${{ env.VERSION }}"
           file: app/build/outputs/apk/release/app-release-unsigned-signed.apk
           asset_name: "Field-Book-v${{ env.VERSION }}.apk"
-          body: "${{ env.RELEASE_NOTES }}"
+          body: "${{ steps.process-changelog.outputs.changelog_additions }}"
 
       - name: Commit Version and Changelog Changes
         if: ${{ success() }}


### PR DESCRIPTION
### Description

<!--
Provide a summary of your changes including motivation and context.  
If these changes fix a bug or resolve a feature request, be sure to link to that issue.
-->

dsda

### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [x] **`CHANGE`** (fix or feature that alters existing functionality)
- [ ] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note
put changelog.xml update logic in separate step
```
___

### Release Type

_For internal use - please leave these unchecked unless you are the one completing the merge._

<!--
- On merge:
  - If `MAJOR` or `MINOR` is checked, a release action will be dispatched to create a release of the selected type.
  - If `WAIT` is checked, the release action will be skipped. The merged changes will later be included in the next dispatched or scheduled release (A scheduled check for unreleased changes runs every Monday at 3pm EST).
-->

- [ ] **`MAJOR`**
- [x] **`MINOR`**
- [ ] **`WAIT`** (No immediate release, but the changelog will be still be updated if there is a release note.)