### PR TITLE
Don't add empty changelog sections in release

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -144,12 +144,48 @@ jobs:
       - name: Process CHANGELOG.md
         id: process-changelog
         run: |
+          # Get the contents under "Unreleased" section
           unreleased_section=$(sed -n '/## \[Unreleased\]/,/^## /p' CHANGELOG.md | sed '1,2d' | sed '$d')
 
-          if [ -z "$unreleased_section" ]; then
+          filtered_content=""
+          current_section=""
+          in_section=false
+
+          while IFS= read -r line; do
+
+            if [[ "$line" =~ ^###[[:space:]]+(Added|Changed|Fixed) ]]; then
+
+              # Found a section header
+              # Remember it, do not add it yet
+
+              current_section="$line"
+              in_section=true
+              section_header_added=false
+
+            elif [[ "$line" =~ ^- ]] && [[ "$in_section" == true ]]; then
+
+              # Found a note under the current section
+
+              if [[ "$section_header_added" == false ]]; then
+                # First note found, section has some content
+                # Add the section header
+                # Set the section_header_added flag as true
+
+                filtered_content+="$current_section"$'\n'
+                section_header_added=true
+              fi
+
+              # Add the note
+              filtered_content+="$line"$'\n'
+
+            fi
+
+          done <<< "$unreleased_section"
+
+          if [ -z "$filtered_content" ]; then
             changelog_escaped="No release notes"
           else
-            changelog_escaped=$(echo "$unreleased_section" | sed 's/^- /✔ /g' | sed ':a;N;$!ba;s/\n/%0A/g')
+            changelog_escaped=$(echo "$filtered_content" | sed 's/^- /✔ /g' | sed ':a;N;$!ba;s/\n/%0A/g')
           fi
 
           echo "changelog_additions=$changelog_escaped" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Description

<!--
Provide a summary of your changes including motivation and context.  
If these changes fix a bug or resolve a feature request, be sure to link to that issue.
-->



### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [x] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [ ] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note
Don't add empty changelog sections in release
```
___

### Release Type

_For internal use - please leave these unchecked unless you are the one completing the merge._

<!--
- On merge:
  - If `MAJOR` or `MINOR` is checked, a release action will be dispatched to create a release of the selected type.
  - If `WAIT` is checked, the release action will be skipped. The merged changes will later be included in the next dispatched or scheduled release (A scheduled check for unreleased changes runs every Monday at 3pm EST).
-->

- [ ] **`MAJOR`**
- [x] **`MINOR`**
- [ ] **`WAIT`** (No immediate release, but the changelog will be still be updated if there is a release note.)