### PR TITLE
Use python script in pr merge workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,18 +34,3 @@ Examples of release notes:
 ```release-note
 
 ```
-___
-
-### Release Type
-
-_For internal use - please leave these unchecked unless you are the one completing the merge._
-
-<!--
-- On merge:
-  - If `MAJOR` or `MINOR` is checked, a release action will be dispatched to create a release of the selected type.
-  - If `WAIT` is checked, the release action will be skipped. The merged changes will later be included in the next dispatched or scheduled release (A scheduled check for unreleased changes runs every Monday at 3pm EST).
--->
-
-- [ ] **`MAJOR`**
-- [ ] **`MINOR`**
-- [ ] **`WAIT`** (No immediate release, but the changelog will be still be updated if there is a release note.)

--- a/.github/workflows/process-pr-merge.yml
+++ b/.github/workflows/process-pr-merge.yml
@@ -2,9 +2,8 @@ name: process-pr-merge
 
 # This workflow processes commits pushed to the main branch to:
 # 1. Determine if the commit is associated with a PR, and if not exit gracefully.
-# 2. Extract relevant details (change type, release note, and bump type) from the PR body
+# 2. Extract relevant details (change type, release note) from the PR body
 #    and use them to update the changelog if applicable (change type is not "OTHER").
-# 3. Trigger a release action if warranted by the bump type (MAJOR, MINOR), or skip if WAIT is selected.
 
 on:
   push:
@@ -46,8 +45,6 @@ jobs:
   update-changelog:
     runs-on: ubuntu-latest
     needs: determine-pr
-    outputs:
-      bump_type: ${{ steps.extract-details.outputs.bump_type }}
     if: needs.determine-pr.outputs.pr_number != ''
     steps:
       - name: Checkout repository
@@ -56,81 +53,15 @@ jobs:
           token: ${{ secrets.ACTIONS_PAT }}
           fetch-depth: 0
 
-      - name: Extract change type, bump type, and release note
-        id: extract-details
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Process PR and update changelog
+        id: process-pr
         run: |
-          pr_number="${{ needs.determine-pr.outputs.pr_number }}"
-          echo "Fetching PR details for PR #$pr_number..."
-
-          # Fetch PR body
-          pr_body=$(gh api -X GET "repos/${{ github.repository }}/pulls/$pr_number" --jq '.body' | sed 's/\r//g')
-          echo "Extracting details from PR Body: $pr_body"
-
-          # Extract release note
-          release_note=$(echo "$pr_body" | awk 'BEGIN { found=0 } /```release-note/ { found=1; next } /```/ { found=0 } found { print }' | sed '/^\s*$/d')
-          echo "Release Note: $release_note"
-          if [ -z "$release_note" ]; then
-            echo "No release note found."
-            exit 1
-          fi
-          echo "release_note=${release_note}" >> $GITHUB_OUTPUT
-
-          # Determine change type
-          change_type=$(echo "$pr_body" | grep -oP '(?<=- \[x\] \*\*`)[A-Z]+(?=`\*\*)' | head -n 1)
-          echo "Change Type: $change_type"
-          case "$change_type" in
-            "ADDITION")
-              section="### Added"
-              ;;
-            "CHANGE")
-              section="### Changed"
-              ;;
-            "FIX")
-              section="### Fixed"
-              ;;
-            "OTHER")
-              echo "Change type is 'OTHER'. Skipping changelog update."
-              exit 0
-              ;;
-            *)
-              echo "Invalid change type: $change_type."
-              exit 1
-              ;;
-          esac
-          echo "section=${section}" >> $GITHUB_OUTPUT
-
-          # Check for bump type
-          major_checked=$(echo "$pr_body" | grep -q '\[x\] \*\*`MAJOR`' && echo "true" || echo "false")
-          minor_checked=$(echo "$pr_body" | grep -q '\[x\] \*\*`MINOR`' && echo "true" || echo "false")
-          wait_checked=$(echo "$pr_body" | grep -q '\[x\] \*\*`WAIT`' && echo "true" || echo "false")
-          if [ "$major_checked" == "true" ]; then
-            echo "bump type: MAJOR"
-            echo "bump_type=major" >> $GITHUB_OUTPUT
-          elif [ "$minor_checked" == "true" ]; then
-            echo "bump type: MINOR"
-            echo "bump_type=minor" >> $GITHUB_OUTPUT
-          elif [ "$wait_checked" == "true" ]; then
-            echo "bump type WAIT was checked. No release required."
-            echo "bump_type=" >> $GITHUB_OUTPUT
-          else
-            echo "No valid bump type specified. Skipping release."
-            echo "bump_type=" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Update changelog
-        run: |
-          section="${{ steps.extract-details.outputs.section }}"
-          note="${{ steps.extract-details.outputs.release_note }}"
-          pr_url="https://github.com/${{ github.repository }}/pull/${{ needs.determine-pr.outputs.pr_number }}"
-          release_note="${note} (${pr_url})"
-          
-          echo "Updating changelog under section: $section"
-
-          # Find the first occurrence of the section
-          # Replace the section with itself and the release note after it
-
-          sed -i "0,/$section/s@$section@$section\n- $release_note@" CHANGELOG.md
-          cat CHANGELOG.md
+          python3 .github/workflows/scripts/process_pr.py "${{ github.repository }}" "${{ needs.determine-pr.outputs.pr_number }}"
 
       - name: Commit and push changelog update
         uses: EndBug/add-and-commit@v7
@@ -141,16 +72,3 @@ jobs:
           author_name: Git Action Bot
           token: ${{ secrets.GITHUB_TOKEN }}
           push: true
-
-  dispatch-release:
-    runs-on: ubuntu-latest
-    needs: update-changelog
-    if: needs.update-changelog.outputs.bump_type != ''
-    steps:
-      - name: Dispatch GitHub Release Action
-        run: |
-          echo "Dispatching release action with bump type: ${{ needs.update-changelog.outputs.bump_type }}"
-          curl -X POST -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-          -H "Accept: application/vnd.github.everest-preview+json" \
-          https://api.github.com/repos/${{ github.repository }}/dispatches \
-          -d '{"event_type": "trigger-release", "client_payload": {"bump_type": "${{ needs.update-changelog.outputs.bump_type }}"}}'

--- a/.github/workflows/scripts/process_pr_merge.py
+++ b/.github/workflows/scripts/process_pr_merge.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+import sys
+import re
+from utils import run_command, read_file, write_file, set_github_output
+
+CHANGE_TYPE_MAPPING = {
+    "ADDITION": "### Added",
+    "CHANGE": "### Changed", 
+    "FIX": "### Fixed",
+    "OTHER": None # this won't be added to changelog
+}
+
+def get_pr_body(repo, pr_number):
+    """Fetch PR body using GitHub CLI"""
+    cmd = f'gh api -X GET "repos/{repo}/pulls/{pr_number}" --jq ".body"'
+    return run_command(cmd).replace('\r', '')
+
+def extract_release_note(pr_body):
+    """Extract release note from PR body"""
+    lines = pr_body.split('\n')
+    is_line_inside_release_note = False
+    release_notes = []
+    
+    for line in lines:
+        if '```release-note' in line:
+            is_line_inside_release_note = True
+            continue
+        elif line.strip() == '```' and is_line_inside_release_note:
+            break
+        elif is_line_inside_release_note and line.strip():
+            release_notes.append(line)
+    
+    release_note = '\n'.join(release_notes).strip()
+
+    if not release_note:
+        print("No release note found. Skipping changelog update.")
+        set_github_output("release_note", "")
+        set_github_output("section", "")
+        sys.exit(0)
+    
+    return release_note
+
+def extract_change_type(pr_body):
+    """Extract change type from PR body"""
+    pattern = r'- \[x\] \*\*`([A-Z]+)`\*\*'
+    match = re.search(pattern, pr_body)
+    
+    if not match:
+        print("No change type found.")
+        sys.exit(0)
+    
+    change_type = match.group(1)
+    
+    section = CHANGE_TYPE_MAPPING.get(change_type)
+
+    if section is None:
+        print(f"Change type '{change_type}' does not require changelog update. Skipping.")
+        sys.exit(0)
+
+    return section
+
+def update_changelog(section, release_note, pr_number, repo):
+    """Update the changelog file"""
+    pr_url = f"https://github.com/{repo}/pull/{pr_number}"
+    full_release_note = f"- {release_note} ({pr_url})"
+    
+    print(f"Updating changelog under section: {section}")
+    
+    content = read_file('CHANGELOG.md')
+    
+    # find the first occurrence of the section and add the release note after it
+    pattern = f"({re.escape(section)})"
+    replacement = f"{section}\n{full_release_note}"
+    
+    # replace only the first occurrence
+    updated_content = re.sub(pattern, replacement, content, count=1)
+    
+    write_file('CHANGELOG.md', updated_content)
+    
+    print("Changelog updated successfully")
+
+def main():
+    if len(sys.argv) != 3:
+        print("Arguments required: <repo> <pr_number>")
+        sys.exit(0)
+    
+    repo = sys.argv[1]
+    pr_number = sys.argv[2]
+    
+    print(f"Processing PR #{pr_number} for repository {repo}")
+    
+    # fetch PR body
+    pr_body = get_pr_body(repo, pr_number)
+    
+    # extract details
+    release_note = extract_release_note(pr_body)
+    section = extract_change_type(pr_body)
+    
+    print(f"Release Note: {release_note}")
+    print(f"Section: {section}")
+    
+    # set outputs for GitHub Actions
+    set_github_output("release_note", release_note)
+    set_github_output("section", section)
+    
+    # update changelog
+    update_changelog(section, release_note, pr_number, repo)
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/scripts/utils.py
+++ b/.github/workflows/scripts/utils.py
@@ -1,0 +1,46 @@
+"""
+This module provides common functions for GitHub Actions 
+automation scripts.
+"""
+
+import os
+import subprocess
+import sys
+
+
+def run_command(cmd):
+    """ Run a shell command and return the output. """
+    result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Error running command: {cmd}")
+        print(f"Error: {result.stderr}")
+        sys.exit(0)
+    return result.stdout.strip()
+
+
+def read_file(file_path):
+    """Read content from a file."""
+    try:
+        with open(file_path, 'r') as f:
+            return f.read()
+    except Exception as e:
+        print(f"Error reading file '{file_path}': {e}")
+        sys.exit(0)
+
+
+def write_file(file_path, content):
+    """Write content to a file."""
+    try:
+        with open(file_path, 'w') as f:
+            f.write(content)
+    except Exception as e:
+        print(f"Error writing to file '{file_path}': {e}")
+        sys.exit(0)
+
+
+def set_github_output(name, value):
+    """ Set GitHub Actions output variable. """
+    github_output = os.environ.get('GITHUB_OUTPUT')
+    if github_output:
+        with open(github_output, 'a') as f:
+            f.write(f"{name}={value}\n")

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ local.properties
 *.jks
 *.keystore
 keystore.config
+
+# python cache files
+__pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Changelog
+
+All notable changes to Field Book app will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## [Unreleased]
 
 ### Added
@@ -19,13 +26,6 @@
 - Fix ordering of steps in workflow (https://github.com/RifeLab/Field-Book-Sandbox/pull/115)
 - fix filtered unreleased sections (https://github.com/RifeLab/Field-Book-Sandbox/pull/114)
 - Does this have a link? (https://github.com/RifeLab/Field-Book-Sandbox/pull/112)
-
-# Changelog
-
-All notable changes to Field Book app will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [v1.2.1] - 2025-01-27
 


### PR DESCRIPTION
### Description



### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [x] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [ ] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note
Use python script in pr merge workflow
```
___

### Release Type

_For internal use - please leave these unchecked unless you are the one completing the merge._

<!--
- On merge:
  - If `MAJOR` or `MINOR` is checked, a release action will be dispatched to create a release of the selected type.
  - If `WAIT` is checked, the release action will be skipped. The merged changes will later be included in the next dispatched or scheduled release (A scheduled check for unreleased changes runs every Monday at 3pm EST).
-->

- [ ] **`MAJOR`**
- [ ] **`MINOR`**
- [x] **`WAIT`** (No immediate release, but the changelog will be still be updated if there is a release note.)